### PR TITLE
Perl for windows

### DIFF
--- a/data/zip-to-csvs.js
+++ b/data/zip-to-csvs.js
@@ -75,7 +75,7 @@ function findAndReplace (match, replace, condition, message) {
     process.stdout.write(`${message}${padding}\r`);
     return new Promise(function(resolve, reject) {
       // Perl has similar syntax to GNU sed and is consistent across operating systems:
-      var command = `perl -i.bak -pe "s/${match}/${replace}/g ${condition||''}" ${fileName}`;
+      var command = `perl -i'*' -pe "s/${match}/${replace}/g ${condition||''}" ${fileName}`;
       exec(command, function (error, stdout, stderr) {
         if (error) {
           console.error(`Execution error: ${error}`);

--- a/data/zip-to-csvs.js
+++ b/data/zip-to-csvs.js
@@ -75,7 +75,7 @@ function findAndReplace (match, replace, condition, message) {
     process.stdout.write(`${message}${padding}\r`);
     return new Promise(function(resolve, reject) {
       // Perl has similar syntax to GNU sed and is consistent across operating systems:
-      var command = `perl -i'*' -pe "s/${match}/${replace}/g ${condition||''}" ${fileName}`;
+      var command = `perl -i.bak -pe "s/${match}/${replace}/g ${condition||''}" ${fileName}`;
       exec(command, function (error, stdout, stderr) {
         if (error) {
           console.error(`Execution error: ${error}`);

--- a/data/zip-to-csvs.js
+++ b/data/zip-to-csvs.js
@@ -88,7 +88,7 @@ function findAndReplace (match, replace, condition, message) {
 }
 
 
-function ammendExtension () {
+function amendExtension () {
   return function (bcpFileName) {
     return new Promise(function(resolve, reject) {
       var csvFileName = bcpFileName.substr(0, bcpFileName.length-4) + '.csv';
@@ -118,7 +118,7 @@ zip.getEntries().forEach(function(zipEntry) {
     var t = tasks[i];
     chain = chain.then(findAndReplace(t.match, t.replace, t.condition, t.message));
   }
-  chain = chain.then(ammendExtension());
+  chain = chain.then(amendExtension());
 })
 
 chain.then(function() {

--- a/data/zip-to-csvs.js
+++ b/data/zip-to-csvs.js
@@ -75,7 +75,7 @@ function findAndReplace (match, replace, condition, message) {
     process.stdout.write(`${message}${padding}\r`);
     return new Promise(function(resolve, reject) {
       // Perl has similar syntax to GNU sed and is consistent across operating systems:
-      var command = `perl -i -pe 's/${match}/${replace}/g ${condition||""}' ${fileName}`;
+      var command = `perl -i.bak -pe "s/${match}/${replace}/g ${condition||''}" ${fileName}`;
       exec(command, function (error, stdout, stderr) {
         if (error) {
           console.error(`Execution error: ${error}`);


### PR DESCRIPTION
Couple of changes for making the perl command work on Windows. Was getting two errors:
- `Can't find string terminator "'" anywhere before EOF at -e line 1.` - fixed by wrapping in `'` rather than `"`
- `Can't do inplace edit without backup.` - fixed by adding `'*'` after `-i` flags

@dan-kwiat - might be worth checking they still work on Mac